### PR TITLE
Allowing GDB to connect

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -33,7 +33,9 @@ DEMO_CXXFLAGS := \
     -MMD \
     -std=c++17 \
     -I$(ROOT_DIR) \
-    $(CFLAGS)
+    $(CFLAGS) \
+	-I$(SPIKE_SOURCE_DIR) # check why is this now needed
+
 
 DEMO_LDFLAGS := -Wl,-rpath,\$$ORIGIN -Wl,-rpath,\$$ORIGIN/lib -Wl,--no-as-needed $(LDFLAGS)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -33,9 +33,7 @@ DEMO_CXXFLAGS := \
     -MMD \
     -std=c++17 \
     -I$(ROOT_DIR) \
-    $(CFLAGS) \
-	-I$(SPIKE_SOURCE_DIR) # check why is this now needed
-
+    $(CFLAGS)
 
 DEMO_LDFLAGS := -Wl,-rpath,\$$ORIGIN -Wl,-rpath,\$$ORIGIN/lib -Wl,--no-as-needed $(LDFLAGS)
 

--- a/src/demo_core.h
+++ b/src/demo_core.h
@@ -17,6 +17,7 @@
 
 #include "riscv/simif.h"      // needed for base class
 #include "riscv/log_file.h"   // for log_file_t
+#include "riscv/debug_module.h"
 
 #include <map>
 #include <memory>
@@ -27,6 +28,9 @@ class processor_t;
 class cfg_t;
 class bus_t;
 class memory_sim_bridge;
+class remote_bitbang_t;
+class debug_module_config_t;
+
 
 class demo_core : public simif_t {
     public:
@@ -34,7 +38,7 @@ class demo_core : public simif_t {
     friend class processor_t;
     friend class mmu_t;
 
-    demo_core(const cfg_t* cfg);
+    demo_core(const cfg_t* cfg, const debug_module_config_t& dm_config);
     ~demo_core();
     
     // pure virtual functions from simif_t
@@ -66,6 +70,13 @@ class demo_core : public simif_t {
         bool debug{false};
         bool log{false};
         log_file_t log_file{"out.txt"}; // Default log file
+        // for GDB
+        remote_bitbang_t* remote_bitbang{nullptr};
+    public:
+    debug_module_t debug_module;
+    void set_remote_bitbang(remote_bitbang_t* remote_bitbang) {
+        this->remote_bitbang = remote_bitbang;
+    }
 };
 
 #endif

--- a/src/main.cc
+++ b/src/main.cc
@@ -16,7 +16,6 @@
 #include "memory_simulator.h"
 #include "riscv/cfg.h"
 #include "riscv/remote_bitbang.h"
-#include "riscv/jtag_dtm.h"
 #include <filesystem>
 #include <iostream>
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -15,12 +15,16 @@
 #include "demo_core.h"
 #include "memory_simulator.h"
 #include "riscv/cfg.h"
+#include "riscv/remote_bitbang.h"
+#include "riscv/jtag_dtm.h"
 #include <filesystem>
 #include <iostream>
 
 #define START_PC 0x20000000
+// #define START_PC 0x10110000
 
-int main() {
+
+int main(int argc, char* argv[]) {
     // configuration time
     cfg_t cfg;
     
@@ -33,6 +37,27 @@ int main() {
     cfg.pmpregions = 16;
     cfg.hartids = {0};
 
+    debug_module_config_t dm_config; // all default params
+
+    uint16_t rbb_port = 0;
+    bool use_rbb = false;
+    unsigned dmi_rti = 0; // TODO: check if this should be parsed from command line
+
+
+    for (int i = 1; i < argc; i++) {
+        std::string arg = argv[i];
+
+        if (arg.find("--rbb-port") != std::string::npos) {
+            size_t pos = arg.find("=");
+            if (pos != std::string::npos) {
+                rbb_port = std::stoi(arg.substr(pos + 1));
+            } 
+            std::cout << "RBB port set to " << rbb_port << std::endl;
+            use_rbb = true;
+        }
+    }
+
+
     // creating external simulator
     #ifdef USE_BRIDGE
     memory_simulator mem_sim(1024 * 1024 * 1024, START_PC);
@@ -43,7 +68,14 @@ int main() {
     // setting cfg field from external simulator
     cfg.external_simulator = &ext_sim;
 
-    demo_core demo_riscv_core(&cfg);
+    demo_core demo_riscv_core(&cfg, dm_config);
+    std::unique_ptr<remote_bitbang_t> remote_bitbang((remote_bitbang_t *) NULL);
+    std::unique_ptr<jtag_dtm_t> jtag_dtm(new jtag_dtm_t(&demo_riscv_core.debug_module, dmi_rti));
+
+    if (use_rbb) {
+      remote_bitbang.reset(new remote_bitbang_t(rbb_port, &(*jtag_dtm)));
+      demo_riscv_core.set_remote_bitbang(&(*remote_bitbang));
+    }
 
 
     // this is runtime from this point


### PR DESCRIPTION
Adding `debug_module_t` and `remote_bitbang_t` to Spike wrapper in order to allow GDB to connect to model